### PR TITLE
feat: add sponsor tracking is sponsored flag to context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/.idea
+/build
+/vendor
+/wp-content
+composer.lock
+.phpcs-cache
+.phplint-cache
+.phpunit.result.cache

--- a/src/Filter/AddIsSponsoredFlagToTimberContext.php
+++ b/src/Filter/AddIsSponsoredFlagToTimberContext.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace IM\Fabric\Plugin\SponsorTracking\Filter;
+
+use IM\Fabric\Package\WordPress\Filter;
+use IM\Fabric\Plugin\SponsorTracking\Action\AdminFields\AddSponsorBox;
+
+/**
+ * @SuppressWarnings(PHPMD.LongVariable)
+ */
+class AddIsSponsoredFlagToTimberContext extends Filter
+{
+    /**
+     * Add the plant details data to the timber context (used for render on the front end)
+     *
+     * @param array ...$args
+     * @return mixed
+     */
+    public function filter(...$args)
+    {
+        [$context] = $args;
+
+        $isSponsoredKey = AddSponsorBox::SPONSOR_TRACKING . '-metabox_'
+              . AddSponsorBox::SPONSOR_TRACKING . '-is-sponsored';
+
+        $context['sponsorTracking']['isSponsored'] = (bool) get_field($isSponsoredKey);
+
+        return $context;
+    }
+}

--- a/src/SponsorTrackingPlugin.php
+++ b/src/SponsorTrackingPlugin.php
@@ -32,6 +32,12 @@ class SponsorTrackingPlugin extends WordPressPlugin
             self::PLUGIN_ID . '-validate-tracking-code',
             $this->get(Filter\ValidateTrackingCode::class)
         );
+
+        # Add isSponsored flag to Timber context when on the 'single' template
+        $this->wordPress->addFilter(
+            'render_content_data_filter',
+            $this->get(Filter\AddIsSponsoredFlagToTimberContext::class)
+        );
     }
 
     /** @SuppressWarnings(PHPMD.StaticAccess) */

--- a/tests/Filter/AddIsSponsoredFlagToTimberContextTest.php
+++ b/tests/Filter/AddIsSponsoredFlagToTimberContextTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IM\Fabric\Plugin\SponsorTracking\Test\Filter;
+
+use IM\Fabric\Plugin\SponsorTracking\Filter\AddIsSponsoredFlagToTimberContext;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WP_Mock\Tools\TestCase;
+use WP_Mock;
+
+class AddIsSponsoredFlagToTimberContextTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /** @dataProvider fieldValueDataProvider */
+    public function testFilterReturnsAppropriateConfig(?bool $fieldValue, bool $expected): void
+    {
+        $expected = [
+            'existingData' => true,
+            'sponsorTracking' => [
+                'isSponsored' => $expected
+            ]
+        ];
+
+        WP_Mock::userFunction('get_field')
+            ->with('sponsor_tracking-metabox_sponsor_tracking-is-sponsored')
+            ->andReturn($fieldValue);
+
+        $actual = (new AddIsSponsoredFlagToTimberContext())->filter(['existingData' => true]);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function fieldValueDataProvider(): array
+    {
+        return [
+            'field value = true' => [true, true],
+            'field value = false' => [false, false],
+            'field value = missing' => [null, false]
+        ];
+    }
+}

--- a/tests/Filter/ValidateTrackingCodeTest.php
+++ b/tests/Filter/ValidateTrackingCodeTest.php
@@ -13,8 +13,8 @@ class ValidateTrackingCodeTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-
     private ValidateTrackingCode $filter;
+
     public function setUp(): void
     {
         $this->filter = new ValidateTrackingCode();

--- a/tests/SponsorTrackingPluginTest.php
+++ b/tests/SponsorTrackingPluginTest.php
@@ -9,6 +9,7 @@ use IM\Fabric\Package\WordPress\WordPress;
 use IM\Fabric\Package\WpPost\PostTypes;
 use IM\Fabric\Plugin\SponsorTracking\Action\AdminFields\AddSponsorBox;
 use IM\Fabric\Plugin\SponsorTracking\Action\LoadPluginTextDomain;
+use IM\Fabric\Plugin\SponsorTracking\Filter\AddIsSponsoredFlagToTimberContext;
 use IM\Fabric\Plugin\SponsorTracking\Filter\ValidateTrackingCode;
 use IM\Fabric\Plugin\SponsorTracking\SponsorTrackingPlugin;
 use Mockery;
@@ -28,7 +29,8 @@ class SponsorTrackingPluginTest extends TestCase
     ];
     private const EXPECTED_FILTERS = [
         ['acf/validate_value/key=field_sponsor_tracking-item-repeater-pixel-code', ValidateTrackingCode::class],
-        ['im-sponsor-tracking-validate-tracking-code', ValidateTrackingCode::class]
+        ['im-sponsor-tracking-validate-tracking-code', ValidateTrackingCode::class],
+        ['render_content_data_filter', AddIsSponsoredFlagToTimberContext::class]
     ];
 
     private SponsorTrackingPlugin $plugin;


### PR DESCRIPTION
| Q                               | A   |
|---------------------------------|-----|
| Jira Ticket                     |  [FAB-48316](https://immediateco.atlassian.net/browse/FAB-48316)   |
| PR Type? (Feature/Bugfix/Chore) |  Feature   |
| Includes Tests? (Y/N)           |  Y   |

Additional resources:
- [Coding Standards](https://immediateco.atlassian.net/wiki/spaces/TL/pages/5250998/Coding+standards)
- [Review Guidelines](https://immediateco.atlassian.net/wiki/spaces/TL/pages/5251007/Code+reviews)
 
This adds new timber context property `sponsor-tracking` that contains an `isSponsored` flag.
This is required in an article template to output the correct 'Advertisement cooperation' sponsor label above the post when `isSponsored` flag is enabled for the post in the WP editor.


[FAB-48316]: https://immediateco.atlassian.net/browse/FAB-48316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ